### PR TITLE
default Support file

### DIFF
--- a/SUPPORT.MD
+++ b/SUPPORT.MD
@@ -1,0 +1,17 @@
+# Support and Help
+
+Need help getting started or using a project? Here's how.
+
+## How to get help
+
+Please seek support in the following ways:
+
+1. :book: **Read the documentation and other guides** for the project to see if you can figure it out on your own. See our documentation in the `readme.md` or on the documentation website. If there is an example project, explore that to learn how it works to see if you can answer your question.
+
+1. :bulb: **Search for answers and ask questions in the discussions tab (if it is enabled).** This is the most appropriate place for debugging issues specific to your use of the project, or figuring out how to use the project in a specific way.
+
+1. :bulb::bulb: **Search for answers and ask questions on [our discord](https://discord.gg/r6AvtnU).** We can help you with quick questions or thoughts. Also you are always welcome to join and enjoy the company of the community.
+
+## Customer Support
+
+For those situations where a more involved need is required, please reach out via [frontside.com](https://frontside.com/) for details on consulting.


### PR DESCRIPTION
This adds a default support file which is subtly exposed in issues and throughout our repos (where we don't already have a `SUPPORT.md`).

![example of tooltip noting our support options](https://docs.github.com/assets/images/help/issues/support_guidelines_in_issue.png)