### PR TITLE
Add PULL REQUEST TEMPLATE for all projects

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Motivation
+
+<!-- REQUIRED
+  Why are you introducing this change? Why is this change necessary? What
+  are you trying to achieve with this change?
+  If you have a relevant issue, add a link directly to the URL here.
+ -->
+
+## Approach
+
+<!-- REQUIRED
+  How does this change fulfill the purpose? Keep it high level. Avoid code-splaining.
+-->
+
+### Alternate Designs
+
+ <!-- OPTIONAL
+   Explain what other alternatives you considered and why you chose this option.
+ -->
+
+### Possible Drawbacks or Risks
+
+ <!-- OPTIONAL
+   What are the possible side-effects or negative impacts of this change?
+ -->
+
+### TODOs and Open Questions
+
+<!-- OPTIONAL
+- [ ] Use GitHub checklists. When solved, check the box and explain the conclusion.
+-->
+
+## Learning
+
+<!-- OPTIONAL
+  Share any blog posts, patterns, libraries, or documentation that helped you.
+-->
+
+## Screenshots
+
+<!-- OPTIONAL
+  If relevant, include "before" and "after" to demonstrate this change. Add a caption describing what each screenshot shows.
+-->


### PR DESCRIPTION
## Motivation

We use a pull request template on all client projects. We even wrote a [blog post about the value of good pull request descriptions](https://frontside.com/blog/2020-05-26-github-actions-pull_request/), but we didn't actually have the pull 
request template that we used applied to Frontside organization. 

This PR correct this wrong, but adding the template to the Frontside organization.

## Approach

Added file PULL_REQUEST_TEMPLATE.md to root directory as per https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository